### PR TITLE
Removed old meetups, add upcoming for 30.11.17

### DIFF
--- a/city.md
+++ b/city.md
@@ -10,48 +10,6 @@
 
 ## Москва
 
-### [moscowcss 5](https://moscowcss.timepad.ru/event/576236/)
-
-31 октября, Москва
-
-### [HighLoad++](http://www.highload.ru/)
-
-7-8 ноября
-
-### [Front Fest Moscow](https://2017.frontfest.ru/)
-
-18 ноября, Москва
-
-<details>
-  <summary>Доклады</summary>
-
-  - «My password doesn't work!», Blaine Cook
-  - «Writing Next level apps», Matheus Fernandes
-  - «Developer's guide to accessibility mechanics», Léonie Watson
-  - «Code & Art», Mathieu Henri
-  - «JavaScript on Things: Electronics for Web Devs», Lyza Danger Gardner
-  - «Six apps — one code with angular», Sani Yusuf
-  - «JavaScript and Node.js — why the ugly duckling is conquering the world?», Franziska Klingner
-  - «Progressive Image Rendering», Jose M. Perez
-  - «Arena Shooter from scratch», Mathieu Henri
-  - «Rendering performance inside out», Martin Splitt
-  - «История одной метрики производительности в Booking.com», Антон Епрев
-  - «Кодстайл и насилие», Антон Немцев
-  - «Интерфейс для 224 стран на 40 языках», Вениамин Тамбурин
-  - «Программисту нужно знать всё», Игорь Алексеенко
-  - «Оптимизация графики на практике», Тим Чаптыков
-  - «React и данные: Эффективные способы хранения и изменения стейта», Алексей Иванов
-  - «React, TypeScript и Redux — как сделать SPA для мобильных браузеров», Егор Банщиков
-  - «(Не очень) молчаливый наблюдатель: что я узнала, наблюдая за JavaScript-экосистемой», Екатерина Пригара
-  - «Декларативная шаблонизация», Владимир Гриненко
-  - «Как переписать крупный проект на Angular и (не) впасть в депрессию», Илья Таратухин
-  - «А что, если мы долетим и там будет всё?», Сергей Попов
-  - «Закложурю ваш джаваскрипт. Дорого. Опыт использования ClojureScript в aviasales.ru», Кирилл Чернышов
-  - «RON: Replicated object notation», Виктор Грищенко
-  - «Алгоритмы и структуры данных меняющие современный Frontend», Владимир Дашукевич
-
-</details>
-
 ### [HolyJS](https://holyjs-moscow.ru/)
 
 10-11 декабря
@@ -71,6 +29,10 @@
 
 </details>
 
+### [Web Standarts Days](https://wsd.events/2018/02/03/)
+
+3 февраля, Москва
+
 <!--
  -->
 ## Санкт-Петербург
@@ -80,31 +42,20 @@
 
 ## Красноярск
 
-### [Dev2Dev](http://dev2dev.ru/)
-
-11 ноября
-
 <!--
  -->
 ## Минск
 
-### [Web Standards Days](https://wsd.events/2017/10/21/)
+### [MinskCss Meetup](https://minskcss.timepad.ru/event/604963/)
 
-21 октября
+7 декабря, Минск
 
 <details>
   <summary>Доклады</summary>
-
-  - «Нодскул в Минске: как и зачем», Тим Маринин
-  - «SSR: DIY», Джеймс Аквух
-  - «Знакомьтесь, модальное окно», Анна Селезнёва
-  - «Людоедский интерфейс», Вадим Макеев
-  - «Рендер HTML в PNG на клиенте», Андрей Роенко
-  - «Duck Hunters TV», Алексей Трусов
-  - «Что не так с Emoji», Алексей Авдеев
-  - «Ответ на главный вопрос в CSS», Михаил Иванкив
-  - «Houdini — великий разоблачитель», Никита Дубко
-  - «Верстальщик. Наследие», Сергей Попов
+  
+  - "Распечатай мне курсач. На CSS" Никита Дубко
+  - "Оценка фронтенда: перестаем тыкать пальцем в небо" Александра Шинкевич
+  - "Солидный фронтенд" Павел Богатырев
 
 </details>
 
@@ -116,74 +67,18 @@
  -->
 
  ## Хабаровск
- ### [Ha.js](https://hajs.ru/)
 
-21 октября, донат  
-<details>
-  <summary>Доклады</summary>
-
-  - «Типы компонентов в Reac», Илья Евсеев
-  - «Тесты без боли», Валентин Игнатьев (ivelum)
-  - «Как завести себе бота», Сергей Голяшой (Эй-Пи Трейд)
-  - «Шаблонизаторы PHP. О пользе для фронтенда», Алекснадр Костюк (Pantera DIgital)
-
-</details>
+<!--
+ -->
 
 ## Харьков
 
-### [Съесть собаку](https://eatdog.com.ua/#poster)
+### [Съесть Собаку](https://eatdog.com.ua/#poster)
 
-12 октября
-
-<details>
-  <summary>Доклады</summary>
-
-  - «Большие проекты, архитектура и фреймворки», Александр Макаров
-  - «Microservices in a wild», Иван Мосев
-
-</details>
-
-### [KharkivJS #8](http://kharkivjs.org/)
-
-28-29 октября
-
-<details>
-  <summary>Доклады</summary>
-
-  - «Effortless Serverless», Aleksandar Simovic
-  - «Pixel shaders for Web developers», Denis Radin
-  - «А что если мы долетим и там будет всё?», Сергей Попов
-  - «Async programming with JavaScript and Node.js», Timur Shemsedinov
-  - «Your last desperate attempt at AngularJS migration», Asim Hussain
-  - «Groupware Systems for fun and profit CRDT, OT, Offline», Max Klymyshyn
-  - «Async exception handling or when something goes wrong», Nick Lototskiy
-  - «How to be a 10x JavaScript developer», Vladimir Polyakov
-  - «Web VR», Denys Dovhan
-  - «Софт скилы», Yuzva Maksim
-  - «Тайны зеленого замочка», Vladimir Dashukevich
-  - «Vue: business-first», Vitalii Ratyshnyi
-  - «Copy-pASTe», Illya Klymov
-  - «Taking care of performance easiest than ever», Artem Denysov
-  - «UVP and the future of CSSinJS», Oleg Slobodskoi
-
-</details>
-
+21 декабря, Харьков
 <!--
  -->
 ## Киев
 
-### [Web Standards Days](https://wsd.events/2017/11/04/)
-
-4 ноября
-
-<details>
-  <summary>Доклады</summary>
-
-  - «CSS in a Components World», Bruce Lawson
-  - «Светлое будущее Custom Elements», Елена Жукова
-  - «Людоедский интерфейс», Вадим Макеев
-  - «Индуктивная доступность», Антон Есауленко
-  - «Оптимизируй это», Денис Завгородний
-  - «Изобретаем велосипед для фриланса», Павел Никитюк
-
-</details>
+<!--
+-->

--- a/date.md
+++ b/date.md
@@ -1,155 +1,26 @@
 # По датам
 
-- [Октябрь](#Октябрь)
-- [Ноябрь](#Ноябрь)
 - [Декабрь](#Декабрь)
 - [Январь](#Январь)
 - [Февраль](#Февраль)
 
 <!--
  -->
-## Октябрь
 
-### [Съесть собаку](https://eatdog.com.ua/#poster)
-
-12 октября, Харьков
-
-<details>
-  <summary>Доклады</summary>
-
-  - «Большие проекты, архитектура и фреймворки», Александр Макаров
-  - «Microservices in a wild», Иван Мосев
-
-</details>
-
-### [Web Standards Days](https://wsd.events/2017/10/21/)
-
-21 октября, Минск
-
-<details>
-  <summary>Доклады</summary>
-
-  - «Нодскул в Минске: как и зачем», Тим Маринин
-  - «SSR: DIY», Джеймс Аквух
-  - «Знакомьтесь, модальное окно», Анна Селезнёва
-  - «Людоедский интерфейс», Вадим Макеев
-  - «Рендер HTML в PNG на клиенте», Андрей Роенко
-  - «Duck Hunters TV», Алексей Трусов
-  - «Что не так с Emoji», Алексей Авдеев
-  - «Ответ на главный вопрос в CSS», Михаил Иванкив
-  - «Houdini — великий разоблачитель», Никита Дубко
-  - «Верстальщик. Наследие», Сергей Попов
-
-</details>
-
-### [Ha.js](https://hajs.ru)
-
-21 октября, Хабаровск
-
-<details>
-  <summary>Доклады</summary>
-
-  - «Типы компонентов в Reac», Илья Евсеев
-  - «Тесты без боли», Валентин Игнатьев (ivelum)
-  - «Как завести себе бота», Сергей Голяшой (Эй-Пи Трейд)
-  - «Шаблонизаторы PHP. О пользе для фронтенда», Алекснадр Костюк (Pantera DIgital)
-
-</details>
-
-### [KharkivJS #8](http://kharkivjs.org/)
-
-28-29 октября, Харьков
-
-<details>
-  <summary>Доклады</summary>
-
-  - «Effortless Serverless», Aleksandar Simovic
-  - «Pixel shaders for Web developers», Denis Radin
-  - «А что если мы долетим и там будет всё?», Сергей Попов
-  - «Async programming with JavaScript and Node.js», Timur Shemsedinov
-  - «Your last desperate attempt at AngularJS migration», Asim Hussain
-  - «Groupware Systems for fun and profit CRDT, OT, Offline», Max Klymyshyn
-  - «Async exception handling or when something goes wrong», Nick Lototskiy
-  - «How to be a 10x JavaScript developer», Vladimir Polyakov
-  - «Web VR», Denys Dovhan
-  - «Софт скилы», Yuzva Maksim
-  - «Тайны зеленого замочка», Vladimir Dashukevich
-  - «Vue: business-first», Vitalii Ratyshnyi
-  - «Copy-pASTe», Illya Klymov
-  - «Taking care of performance easiest than ever», Artem Denysov
-  - «UVP and the future of CSSinJS», Oleg Slobodskoi
-
-</details>
-
-### [moscowcss 5](https://moscowcss.timepad.ru/event/576236/)
-
-31 октября, Москва
-
-<!--
- -->
-## Ноябрь
-
-### [Web Standards Days](https://wsd.events/2017/11/04/)
-
-4 ноября, Киев
-
-<details>
-  <summary>Доклады</summary>
-
-  - «CSS in a Components World», Bruce Lawson
-  - «Светлое будущее Custom Elements», Елена Жукова
-  - «Людоедский интерфейс», Вадим Макеев
-  - «Индуктивная доступность», Антон Есауленко
-  - «Оптимизируй это», Денис Завгородний
-  - «Изобретаем велосипед для фриланса», Павел Никитюк
-
-</details>
-
-### [HighLoad++](http://www.highload.ru/)
-
-7-8 ноября, Москва
-
-### [Dev2Dev](http://dev2dev.ru/)
-
-11 ноября, Красноярск
-
-### [Front Fest Moscow](https://2017.frontfest.ru/)
-
-18 ноября, Москва
-
-<details>
-  <summary>Доклады</summary>
-
-  - «My password doesn't work!», Blaine Cook
-  - «Writing Next level apps», Matheus Fernandes
-  - «Developer's guide to accessibility mechanics», Léonie Watson
-  - «Code & Art», Mathieu Henri
-  - «JavaScript on Things: Electronics for Web Devs», Lyza Danger Gardner
-  - «Six apps — one code with angular», Sani Yusuf
-  - «JavaScript and Node.js — why the ugly duckling is conquering the world?», Franziska Klingner
-  - «Progressive Image Rendering», Jose M. Perez
-  - «Arena Shooter from scratch», Mathieu Henri
-  - «Rendering performance inside out», Martin Splitt
-  - «История одной метрики производительности в Booking.com», Антон Епрев
-  - «Кодстайл и насилие», Антон Немцев
-  - «Интерфейс для 224 стран на 40 языках», Вениамин Тамбурин
-  - «Программисту нужно знать всё», Игорь Алексеенко
-  - «Оптимизация графики на практике», Тим Чаптыков
-  - «React и данные: Эффективные способы хранения и изменения стейта», Алексей Иванов
-  - «React, TypeScript и Redux — как сделать SPA для мобильных браузеров», Егор Банщиков
-  - «(Не очень) молчаливый наблюдатель: что я узнала, наблюдая за JavaScript-экосистемой», Екатерина Пригара
-  - «Декларативная шаблонизация», Владимир Гриненко
-  - «Как переписать крупный проект на Angular и (не) впасть в депрессию», Илья Таратухин
-  - «А что, если мы долетим и там будет всё?», Сергей Попов
-  - «Закложурю ваш джаваскрипт. Дорого. Опыт использования ClojureScript в aviasales.ru», Кирилл Чернышов
-  - «RON: Replicated object notation», Виктор Грищенко
-  - «Алгоритмы и структуры данных меняющие современный Frontend», Владимир Дашукевич
-
-</details>
-
-<!--
- -->
 ## Декабрь
+
+### [MinskCss Meetup](https://minskcss.timepad.ru/event/604963/)
+
+7 декабря, Минск
+
+<details>
+  <summary>Доклады</summary>
+  
+  - "Распечатай мне курсач. На CSS" Никита Дубко
+  - "Оценка фронтенда: перестаем тыкать пальцем в небо" Александра Шинкевич
+  - "Солидный фронтенд" Павел Богатырев
+
+</details>
 
 ### [HolyJS](https://holyjs-moscow.ru/)
 
@@ -170,6 +41,10 @@
 
 </details>
 
+### [Съесть Собаку](https://eatdog.com.ua/#poster)
+
+21 декабря, Харьков
+
 <!--
  -->
 ## Январь
@@ -177,6 +52,10 @@
 <!--
  -->
 ## Февраль
+
+### [Web Standarts Days](https://wsd.events/2018/02/03/)
+
+3 февраля, Москва
 
 ### [The Rolling Scopes Conference](https://2018.conf.rollingscopes.com/)
 


### PR DESCRIPTION
Новые события:

- [Web Standarts Days](https://wsd.events/2018/02/03/)
3 февраля, Москва

- [MinskCss Meetup](https://minskcss.timepad.ru/event/604963/)
7 декабря, Минск

- [Съесть Собаку](https://eatdog.com.ua/#poster)
21 декабря, Харьков



Новые доклады:

- [MinskCss Meetup](https://minskcss.timepad.ru/event/604963/)
- "Распечатай мне курсач. На CSS" Никита Дубко
- "Оценка фронтенда: перестаем тыкать пальцем в небо" Александра Шинкевич
- "Солидный фронтенд" Павел Богатырев